### PR TITLE
Disable iOS compiler optimization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-Runtime/NearbyConnections/Plugins/iOS/libNearbyUnityPlugin.a filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Fix for #7 
The iOS crash was due to compiler optimization, so avoid optimizing it.